### PR TITLE
feat: publish repo to CDN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to S3
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+env:
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  GIT_REPO_OWNER: ${{ github.repository_owner }}
+  GIT_REPO: ${{ github.repository }}
+  AWS_ROLE_ARN: arn:aws:iam::024848458133:role/github_oidc_FuelLabs_chain-configuration
+  AWS_S3_BUCKET: fuel-prod-chain-configuration-assets-origin
+  AWS_S3_REGION: us-east-1
+
+jobs:
+  publish-to-s3:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_S3_REGION }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install s3cmd tool
+        run: pip install s3cmd
+
+      - name: Sync files to S3
+        run: s3cmd sync —exclude '.git*' --delete-removed ./ s3://${{ env.AWS_S3_BUCKET }}/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.terraform
+*.tfstate*
+*.terraform.lock.hcl*
+.vscode
+.envrc
+.direnv
+.cov
+.idea
+.env


### PR DESCRIPTION
Publish the contents of this repository to S3 so we do not need to rely on GitHub for config distribution.